### PR TITLE
Gemspec fix

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,8 @@
 source :rubygems
 
 gem 'bundler', '>= 1.0.7', :require => 'bundle', :group => [:test, :development]
-gem 'rspec', '>= 2', :group => :test
-gem 'epubcheck', '>= 0.1.0', :group => :test
+gem 'rspec', '>= 2', :group => [:test, :development]
+gem 'epubcheck', '>= 0.1.0', :group => [:test, :development]
 gem 'jeweler', '>= 1.5.1', :group => :development
 gem 'libxml-ruby', '>= 1.1.4'
 gem 'rubyzip', '>= 0.9.4'

--- a/Rakefile
+++ b/Rakefile
@@ -10,12 +10,6 @@ begin
     gem.email = "skoji@skoji.jp"
     gem.homepage = "http://github.com/skoji/gepub"
     gem.authors = ["KOJIMA Satoshi"]
-    gem.add_development_dependency "rspec", ">= 2"
-    gem.add_development_dependency "epubcheck", ">= 0.1.0"
-    gem.add_development_dependency "bundler", ">= 1.0.7"
-    gem.add_development_dependency "jeweler", ">= 1.5.1"
-    gem.add_dependency('libxml-ruby', ">= 1.1.4")
-    gem.add_dependency('rubyzip', ">= 0.9.4")
     # gem is a Gem::Specification... see http://www.rubygems.org/read/chapter/20 for additional settings
   end
   Jeweler::GemcutterTasks.new

--- a/gepub.gemspec
+++ b/gepub.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["KOJIMA Satoshi"]
-  s.date = %q{2011-01-06}
+  s.date = %q{2011-01-08}
   s.description = %q{an easy-to-use (and easy-to-implement) EPUB generator.}
   s.email = %q{skoji@skoji.jp}
   s.extra_rdoc_files = [
@@ -48,36 +48,24 @@ Gem::Specification.new do |s|
       s.add_runtime_dependency(%q<libxml-ruby>, [">= 1.1.4"])
       s.add_runtime_dependency(%q<rubyzip>, [">= 0.9.4"])
       s.add_development_dependency(%q<bundler>, [">= 1.0.7"])
-      s.add_development_dependency(%q<jeweler>, [">= 1.5.1"])
       s.add_development_dependency(%q<rspec>, [">= 2"])
       s.add_development_dependency(%q<epubcheck>, [">= 0.1.0"])
-      s.add_development_dependency(%q<bundler>, [">= 1.0.7"])
       s.add_development_dependency(%q<jeweler>, [">= 1.5.1"])
-      s.add_runtime_dependency(%q<libxml-ruby>, [">= 1.1.4"])
-      s.add_runtime_dependency(%q<rubyzip>, [">= 0.9.4"])
     else
       s.add_dependency(%q<libxml-ruby>, [">= 1.1.4"])
       s.add_dependency(%q<rubyzip>, [">= 0.9.4"])
       s.add_dependency(%q<bundler>, [">= 1.0.7"])
-      s.add_dependency(%q<jeweler>, [">= 1.5.1"])
       s.add_dependency(%q<rspec>, [">= 2"])
       s.add_dependency(%q<epubcheck>, [">= 0.1.0"])
-      s.add_dependency(%q<bundler>, [">= 1.0.7"])
       s.add_dependency(%q<jeweler>, [">= 1.5.1"])
-      s.add_dependency(%q<libxml-ruby>, [">= 1.1.4"])
-      s.add_dependency(%q<rubyzip>, [">= 0.9.4"])
     end
   else
     s.add_dependency(%q<libxml-ruby>, [">= 1.1.4"])
     s.add_dependency(%q<rubyzip>, [">= 0.9.4"])
     s.add_dependency(%q<bundler>, [">= 1.0.7"])
-    s.add_dependency(%q<jeweler>, [">= 1.5.1"])
     s.add_dependency(%q<rspec>, [">= 2"])
     s.add_dependency(%q<epubcheck>, [">= 0.1.0"])
-    s.add_dependency(%q<bundler>, [">= 1.0.7"])
     s.add_dependency(%q<jeweler>, [">= 1.5.1"])
-    s.add_dependency(%q<libxml-ruby>, [">= 1.1.4"])
-    s.add_dependency(%q<rubyzip>, [">= 0.9.4"])
   end
 end
 


### PR DESCRIPTION
When I added Gemfile I didn't see that Jeweler parses it and adds gems to Gemfile. This resulted in duplicated entries. This patch removes all dependencies from Rakefile and adds test gems to development group so that they will be pulled to gemspec as development dependencies.
