### PR TITLE
Updates examples to require rubygems

### DIFF
--- a/examples/builder_example.rb
+++ b/examples/builder_example.rb
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-    require 'rubygem'
+    require 'rubygems'
     require 'gepub'
     workdir = 'epub/example/'
     builder = GEPUB::Builder.new {

--- a/examples/generate_example.rb
+++ b/examples/generate_example.rb
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-require 'rubygem'
+require 'rubygems'
 require 'gepub'
 
 book = GEPUB::Book.new


### PR DESCRIPTION
The examples didn't seem to work as they required 'rubygem' instead of 'rubygems'. I've updated.
