### PR TITLE
Remove use of 'zip' gem dependencies

### DIFF
--- a/lib/gepub/book.rb
+++ b/lib/gepub/book.rb
@@ -102,7 +102,7 @@ module GEPUB
       files = {}
       package = nil
       package_path = nil
-      Zip::ZipInputStream::open_buffer(io) {
+      Zip::InputStream::open_buffer(io) {
         |zis|
         package, package_path = parse_container(zis, files)
         check_consistency_of_package(package, package_path)
@@ -213,7 +213,7 @@ module GEPUB
 
     # write EPUB to stream specified by the argument.
     def write_to_epub_container(epub)
-      epub.put_next_entry('mimetype', '', '', Zip::ZipEntry::STORED)
+      epub.put_next_entry('mimetype', '', '', Zip::Entry::STORED)
       epub << "application/epub+zip"
 
       entries = {}
@@ -241,7 +241,7 @@ module GEPUB
     # generates and returns StringIO contains EPUB.
     def generate_epub_stream
       cleanup
-      Zip::ZipOutputStream::write_buffer {
+      Zip::OutputStream::write_buffer {
         |epub|
         write_to_epub_container(epub)
       }
@@ -251,7 +251,7 @@ module GEPUB
     def generate_epub(path_to_epub)
       cleanup
       File.delete(path_to_epub) if File.exist?(path_to_epub)
-      Zip::ZipOutputStream::open(path_to_epub) {
+      Zip::OutputStream::open(path_to_epub) {
         |epub|
         write_to_epub_container(epub)
       }


### PR DESCRIPTION
Remove parts of code that depends on of 'zip' gem instead of rubyzip:
- Zip::ZipEntry -> Zip::Entry
- Zip::ZipOutputStream -> Zip::OutputStream
- Zip::ZipInputStream -> Zip::InputStream

Here's the error stacktrace I had when generating:

/home/vincent/.rvm/gems/ruby-2.1.0/gems/zip-2.0.2/lib/zip/zip.rb:959:in `put_next_entry': wrong number of arguments (4 for 1..2) (ArgumentError)
    from /home/vincent/.rvm/gems/ruby-2.1.0/gems/gepub-0.6.4.6/lib/gepub/book.rb:240:in`write_to_epub_container'
    from /home/vincent/.rvm/gems/ruby-2.1.0/gems/gepub-0.6.4.6/lib/gepub/book.rb:272:in `block in generate_epub'
    from /home/vincent/.rvm/gems/ruby-2.1.0/gems/zip-2.0.2/lib/zip/zip.rb:942:in`open'
    from /home/vincent/.rvm/gems/ruby-2.1.0/gems/gepub-0.6.4.6/lib/gepub/book.rb:270:in `generate_epub'
    from /home/vincent/git/sitepub/lib/sitepub/generators/epub_writer.rb:40:in`create_epub'
    from /home/vincent/git/egen/lib/tasks/generator.thor:14:in `generate_epub'
    from /home/vincent/.rvm/gems/ruby-2.1.0/gems/thor-0.18.1/lib/thor/command.rb:27:in`run'
    from /home/vincent/.rvm/gems/ruby-2.1.0/gems/thor-0.18.1/lib/thor/invocation.rb:120:in `invoke_command'
    from /home/vincent/.rvm/gems/ruby-2.1.0/gems/thor-0.18.1/lib/thor.rb:363:in`dispatch'
    from /home/vincent/.rvm/gems/ruby-2.1.0/gems/thor-0.18.1/lib/thor/base.rb:439:in `start'
    from /home/vincent/.rvm/gems/ruby-2.1.0/gems/thor-0.18.1/lib/thor/runner.rb:36:in`method_missing'
    from /home/vincent/.rvm/gems/ruby-2.1.0/gems/thor-0.18.1/lib/thor/command.rb:29:in `run'
    from /home/vincent/.rvm/gems/ruby-2.1.0/gems/thor-0.18.1/lib/thor/command.rb:128:in`run'
    from /home/vincent/.rvm/gems/ruby-2.1.0/gems/thor-0.18.1/lib/thor/invocation.rb:120:in `invoke_command'
    from /home/vincent/.rvm/gems/ruby-2.1.0/gems/thor-0.18.1/lib/thor.rb:363:in`dispatch'
    from /home/vincent/.rvm/gems/ruby-2.1.0/gems/thor-0.18.1/lib/thor/base.rb:439:in `start'
    from /home/vincent/.rvm/gems/ruby-2.1.0/gems/thor-0.18.1/bin/thor:6:in`<top (required)>'
    from /home/vincent/.rvm/gems/ruby-2.1.0/bin/thor:23:in `load'
    from /home/vincent/.rvm/gems/ruby-2.1.0/bin/thor:23:in`<main>'
    from /home/vincent/.rvm/gems/ruby-2.1.0/bin/ruby_executable_hooks:15:in `eval'
    from /home/vincent/.rvm/gems/ruby-2.1.0/bin/ruby_executable_hooks:15:in`<main>'
