### PR TITLE
Update GEPUB::Item#guess_content_property

### DIFF
--- a/lib/gepub/item.rb
+++ b/lib/gepub/item.rb
@@ -98,7 +98,8 @@ module GEPUB
         if parsed.xpath("//epub:switch", { 'epub' => 'http://www.idpf.org/2007/ops' }).size > 0
           self.add_property('switch')
         end
-        if parsed.xpath("//#{prefix}script").size > 0
+        scripts = parsed.xpath("//#{prefix}script") + parsed.xpath("//#{prefix}form")
+        if scripts.size > 0 && parsed.root.node_name === "html"
           self.add_property('scripted')
         end
       end

--- a/lib/gepub/item.rb
+++ b/lib/gepub/item.rb
@@ -73,7 +73,7 @@ module GEPUB
 
     # guess and set content property from contents.
     def guess_content_property
-      if File.extname(self.href) =~ /.x?html/
+      if File.extname(self.href) =~ /.x?html/ && @attributes['media-type'] === 'application/xhtml+xml'
         @attributes['properties'] = (@attributes['properties'] || []).reject {
           |x| x == 'svg' || x == 'mathml' || x == 'switch' || x == 'remote-resources'
         }

--- a/lib/gepub/item.rb
+++ b/lib/gepub/item.rb
@@ -84,8 +84,8 @@ module GEPUB
         else
           prefix = "#{ns_prefix}:"
         end
-        videos = parsed.xpath("//#{prefix}video[starts-with(@src,'http')]")
-        audios = parsed.xpath("//#{prefix}audio[starts-with(@src,'http')]")
+        videos = parsed.xpath("//#{prefix}video[starts-with(@src,'http')]") + parsed.xpath("//#{prefix}video/#{prefix}source[starts-with(@src,'http')]")
+        audios = parsed.xpath("//#{prefix}audio[starts-with(@src,'http')]") + parsed.xpath("//#{prefix}audio/#{prefix}source[starts-with(@src,'http')]")
         if videos.size > 0 || audios.size > 0
           self.add_property('remote-resources')
         end

--- a/lib/gepub/item.rb
+++ b/lib/gepub/item.rb
@@ -78,6 +78,7 @@ module GEPUB
           |x| x == 'svg' || x == 'mathml' || x == 'switch' || x == 'remote-resources'
         }
         parsed = Nokogiri::XML::Document.parse(@content)
+        return unless parsed.root.node_name === "html"
         ns_prefix =  parsed.namespaces.invert['http://www.w3.org/1999/xhtml']
         if ns_prefix.nil?
           prefix = ''
@@ -99,7 +100,7 @@ module GEPUB
           self.add_property('switch')
         end
         scripts = parsed.xpath("//#{prefix}script") + parsed.xpath("//#{prefix}form")
-        if scripts.size > 0 && parsed.root.node_name === "html"
+        if scripts.size > 0
           self.add_property('scripted')
         end
       end


### PR DESCRIPTION
Properties should only be added to valid documents that will render in a reading system, not just any document with the right extension. It sounds crazy that non-rendering documents might end up in an EPUB, but there are valid use cases.

Also added support for video and audio source elements for 'remote-resources'. Forms have been added for 'scripted' elements to comply with [Scripted Content Documents](http://www.idpf.org/epub/301/spec/epub-contentdocs.html#sec-scripted-content) spec.