### PR TITLE
Change version boundary for nokogiri to >= 1.6.1, < 1.8

### DIFF
--- a/gepub.gemspec
+++ b/gepub.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_runtime_dependency "nokogiri", "~> 1.6.1"
+  s.add_runtime_dependency "nokogiri", ">= 1.6.1", "< 1.8"
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec"
   s.add_runtime_dependency "rubyzip", ">= 1.1.1"


### PR DESCRIPTION
All tests pass with latest nokogiri 1.7.1.