### PR TITLE
fix method redefined errors

### DIFF
--- a/lib/gepub/builder.rb
+++ b/lib/gepub/builder.rb
@@ -190,7 +190,9 @@ module GEPUB
     # define base methods.
     GEPUB::Metadata::CONTENT_NODE_LIST.each {
       |name|
-      define_method(name) { |val| @last_defined_item = MetaItem.new(@book.send("add_#{name}".to_sym, val, nil)) }
+      if !["title", "creator", "contributor"].include?(name)
+        define_method(name) { |val| @last_defined_item = MetaItem.new(@book.send("add_#{name}".to_sym, val, nil)) }
+      end
     }
 
     GEPUB::TITLE_TYPE::TYPES.each {
@@ -205,7 +207,9 @@ module GEPUB
       else
         methodname = type
       end
-      define_method(methodname) { |val| @last_defined_item = MetaItem.new(@book.add_title(val, nil, type)) }
+      if methodname != "collection"
+        define_method(methodname) { |val| @last_defined_item = MetaItem.new(@book.add_title(val, nil, type)) }
+      end
     }
 
     def collection(val, count = 1)

--- a/lib/gepub/metadata.rb
+++ b/lib/gepub/metadata.rb
@@ -119,6 +119,8 @@ module GEPUB
         end
       }
 
+      next if node == 'title'
+
       define_method(node, ->(content=UNASSIGNED, id=nil) {
                       if unassigned?(content)
                         get_first_node(node)
@@ -128,11 +130,6 @@ module GEPUB
                       end
                     })
 
-      define_method('add_' + node) {
-        |content, id|
-        add_metadata(node, content, id)
-      }
-      
       define_method('set_' + node) {
         |content, id|
         warn "obsolete : set_#{node}. use #{node} instead."
@@ -144,6 +141,13 @@ module GEPUB
         |content|
         send(node + "_clear")
         add_metadata(node, content, nil)
+      }
+
+      next if ["identifier", "date", "creator", "contributor"].include?(node)
+
+      define_method('add_' + node) {
+        |content, id|
+        add_metadata(node, content, id)
       }
     }
 

--- a/lib/gepub/package.rb
+++ b/lib/gepub/package.rb
@@ -11,7 +11,11 @@ module GEPUB
     def_delegators :@manifest, :item_by_href
     def_delegators :@metadata, *Metadata::CONTENT_NODE_LIST.map {
       |x|
-      ["#{x}", "#{x}_list", "set_#{x}", "#{x}=", "add_#{x}"]
+      if x == "identifier"
+        ["#{x}_list", "set_#{x}", "add_#{x}"]
+      else
+        ["#{x}", "#{x}_list", "set_#{x}", "#{x}=", "add_#{x}"]
+      end
     }.flatten
     def_delegators :@metadata, :set_lastmodified
     def_delegators :@metadata, :lastmodified


### PR DESCRIPTION
I got erros when executing with `-w` option.

### before

```
$ ruby -S -w rspec 
[Coveralls] Set up the SimpleCov formatter.
[Coveralls] Using SimpleCov's default settings.
/Users/maki/git/gepub/lib/gepub/metadata.rb:161: warning: method redefined; discarding old title=
/Users/maki/git/gepub/lib/gepub/metadata.rb:143: warning: previous definition of title= was here
/Users/maki/git/gepub/lib/gepub/metadata.rb:165: warning: method redefined; discarding old title
/Users/maki/git/gepub/lib/gepub/metadata.rb:122: warning: previous definition of title was here
/Users/maki/git/gepub/lib/gepub/metadata.rb:189: warning: method redefined; discarding old add_identifier
/Users/maki/git/gepub/lib/gepub/metadata.rb:131: warning: previous definition of add_identifier was here
/Users/maki/git/gepub/lib/gepub/metadata.rb:197: warning: method redefined; discarding old add_date
/Users/maki/git/gepub/lib/gepub/metadata.rb:131: warning: previous definition of add_date was here
/Users/maki/git/gepub/lib/gepub/metadata.rb:216: warning: method redefined; discarding old add_title
/Users/maki/git/gepub/lib/gepub/metadata.rb:131: warning: previous definition of add_title was here
/Users/maki/git/gepub/lib/gepub/metadata.rb:222: warning: method redefined; discarding old set_title
/Users/maki/git/gepub/lib/gepub/metadata.rb:136: warning: previous definition of set_title was here
/Users/maki/git/gepub/lib/gepub/metadata.rb:236: warning: method redefined; discarding old add_creator
/Users/maki/git/gepub/lib/gepub/metadata.rb:131: warning: previous definition of add_creator was here
/Users/maki/git/gepub/lib/gepub/metadata.rb:242: warning: method redefined; discarding old add_contributor
/Users/maki/git/gepub/lib/gepub/metadata.rb:131: warning: previous definition of add_contributor was here
/Users/maki/git/gepub/lib/gepub/package.rb:150: warning: method redefined; discarding old identifier
/Users/maki/.rbenv/versions/2.5.0/lib/ruby/2.5.0/forwardable.rb:220: warning: previous definition of identifier was here
/Users/maki/git/gepub/lib/gepub/package.rb:158: warning: method redefined; discarding old identifier=
/Users/maki/.rbenv/versions/2.5.0/lib/ruby/2.5.0/forwardable.rb:220: warning: previous definition of identifier= was here
/Users/maki/git/gepub/lib/gepub/builder.rb:208: warning: method redefined; discarding old title
/Users/maki/git/gepub/lib/gepub/builder.rb:193: warning: previous definition of title was here
/Users/maki/git/gepub/lib/gepub/builder.rb:211: warning: method redefined; discarding old collection
/Users/maki/git/gepub/lib/gepub/builder.rb:208: warning: previous definition of collection was here
/Users/maki/git/gepub/lib/gepub/builder.rb:216: warning: method redefined; discarding old creator
/Users/maki/git/gepub/lib/gepub/builder.rb:193: warning: previous definition of creator was here
/Users/maki/git/gepub/lib/gepub/builder.rb:259: warning: method redefined; discarding old contributor
/Users/maki/git/gepub/lib/gepub/builder.rb:193: warning: previous definition of contributor was here
/Users/maki/git/gepub/spec/gepub_spec.rb:222: warning: assigned but unused variable - item2

GEPUB::Bindings
  parse existing opf
    should be parsed
  generate new opf
```

### after

```
$ ruby -S -w rspec 
[Coveralls] Set up the SimpleCov formatter.
[Coveralls] Using SimpleCov's default settings.
/Users/maki/git/gepub/spec/gepub_spec.rb:222: warning: assigned but unused variable - item2

GEPUB::Bindings
  parse existing opf
    should be parsed
  generate new opf
    should generate xml
```