### PR TITLE
README: fix rendering error(?) in GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ a generic EPUB parser/generator library.
 
 If you are using GEPUB::Builder from your code and do not like its behaviour(e.g. the block inside is evaluated as inside the Builder instance), please consider using GEPUB::Book directly.
 
-** GEPUB::Builder will be obsolete in gepub 0.7. GEPUB::Book#new will be enhanced instead of Builder DSL. **
+**GEPUB::Builder will be obsolete in gepub 0.7. GEPUB::Book#new will be enhanced instead of Builder DSL.**
 
 
 ## SYNOPSIS:


### PR DESCRIPTION
`** foo **` is not bold in GitHub README.md.

### before

![2018-05-03 1 41 33](https://user-images.githubusercontent.com/10401/39537009-3d7706b2-4e73-11e8-9a3f-5fb167c320ab.png)

### after

![2018-05-03 1 41 45](https://user-images.githubusercontent.com/10401/39537017-440c51f8-4e73-11e8-876e-e25ae4bceb0c.png)
