### PR TITLE
fix an example script

### DIFF
--- a/examples/new_book_example.rb
+++ b/examples/new_book_example.rb
@@ -1,20 +1,18 @@
 # -*- coding: utf-8 -*-
 require 'gepub'
 
-GEPUB::Book.new do |book|
-  book.set_unique_identifier 'http:/example.jp/bookid_in_url', 'BookID', 'URL'
-  book.set_title 'GEPUB Sample Book'
-  book.set_subtitle 'GEPUB Sample Book'
-  book.set_creator 'KOJIMA Satoshi'
-  book.set_contributors '電書部', 'アサガヤデンショ', '電子雑誌トルタル'
+gbook = GEPUB::Book.new do |book|
+  book.identifier = 'http://example.jp/bookid_in_url'
+  book.title = 'GEPUB Sample Book'
+  book.creator = 'KOJIMA Satoshi'
+  book.contributor = '電書部'
+  book.add_contributor 'アサガヤデンショ'
+  book.add_contributor '電子雑誌トルタル'
+  book.language = 'ja'
 
-  book.ordered {
-    book.add_item('name') do
-      |item|
-      item.content = StringIO.new()
-    end
-  }
+  book.ordered do
+    item = book.add_item('name.xhtml')
+    item.add_content StringIO.new('<html xmlns="http://www.w3.org/1999/xhtml"><head><title>c1</title></head><body><p>the first page</p></body></html>')end
 end
 
-
-
+gbook.generate_epub("test.epub")


### PR DESCRIPTION
`examples/new_book_example.rb` seems to be broken.

```
$ ruby examples/new_book_example.rb 
Traceback (most recent call last):
	5: from examples/new_book_example.rb:4:in `<main>'
	4: from examples/new_book_example.rb:4:in `new'
	3: from /Users/maki/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/gepub-0.7.0/lib/gepub/book.rb:128:in `initialize'
	2: from examples/new_book_example.rb:5:in `block in <main>'
	1: from /Users/maki/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/gepub-0.7.0/lib/gepub/book.rb:194:in `method_missing'
/Users/maki/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/gepub-0.7.0/lib/gepub/package.rb:128:in `block (2 levels) in <class:Package>': wrong number of arguments (given 3, expected 1) (ArgumentError)
```