### PR TITLE
fix an example sccript: generate_example.rb

### DIFF
--- a/examples/generate_example.rb
+++ b/examples/generate_example.rb
@@ -3,7 +3,7 @@ require 'rubygems'
 require 'gepub'
 
 book = GEPUB::Book.new
-book.set_main_id('http:/example.jp/bookid_in_url', 'BookID', 'URL')
+book.primary_identifier('http://example.jp/bookid_in_url', 'BookID', 'URL')
 book.language = 'ja'
 
 # you can add metadata and its property using block
@@ -18,18 +18,18 @@ book.add_title('GEPUBサンプル文書', nil, GEPUB::TITLE_TYPE::MAIN) {
                        'th' => 'GEPUB ตัวอย่าง (ญี่ปุ่น)')
 }
 # you can do the same thing using method chain
-book.add_title('これはあくまでサンプルです',nil, GEPUB::TITLE_TYPE::SUBTITLE).set_display_seq(1).add_alternates('en' => 'this book is just a sample.')
+book.add_title('これはあくまでサンプルです',nil, GEPUB::TITLE_TYPE::SUBTITLE).display_seq(1).add_alternates('en' => 'this book is just a sample.')
 book.add_creator('小嶋智') {
   |creator|
   creator.display_seq = 1
   creator.add_alternates('en' => 'KOJIMA Satoshi')
 }
-book.add_contributor('電書部').set_display_seq(1).add_alternates('en' => 'Denshobu')
-book.add_contributor('アサガヤデンショ').set_display_seq(2).add_alternates('en' => 'Asagaya Densho')
-book.add_contributor('湘南電書鼎談').set_display_seq(3).add_alternates('en' => 'Shonan Densho Teidan')
-book.add_contributor('電子雑誌トルタル').set_display_seq(4).add_alternates('en' => 'eMagazine Torutaru')
+book.add_contributor('電書部').display_seq(1).add_alternates('en' => 'Denshobu')
+book.add_contributor('アサガヤデンショ').display_seq(2).add_alternates('en' => 'Asagaya Densho')
+book.add_contributor('湘南電書鼎談').display_seq(3).add_alternates('en' => 'Shonan Densho Teidan')
+book.add_contributor('電子雑誌トルタル').display_seq(4).add_alternates('en' => 'eMagazine Torutaru')
 
-imgfile = File.join(File.dirname(__FILE__),  'img', 'image1.jpg')
+imgfile = File.join(File.dirname(__FILE__),  'image1.jpg')
 File.open(imgfile) do
   |io|
   book.add_item('img/image1.jpg',io).cover_image


### PR DESCRIPTION
I got another error when executing `example/generate_example.rb`.

```console
$ bundle exec ruby examples/generate_example.rb 
Traceback (most recent call last):
	1: from examples/generate_example.rb:6:in `<main>'
/Users/maki/git/gepub/lib/gepub/book.rb:194:in `method_missing': undefined method `set_main_id' for #<GEPUB::Package:0x00007fa097981f18> (NoMethodError)
Did you mean?  set_lang
```