### PR TITLE
fix error in Meta#to_s with an argument

### DIFF
--- a/lib/gepub/meta.rb
+++ b/lib/gepub/meta.rb
@@ -143,7 +143,7 @@ module GEPUB
         }.reverse
         localized = candidates[0].content if candidates.size > 0
       end
-      (localized || self.content || super).to_s
+      (localized || self.content || super()).to_s
     end
   end
 end


### PR DESCRIPTION
### before

```
$ bundle exec irb
irb(main):001:0> require "gepub"
=> true
irb(main):002:0> m=GEPUB::Meta.new("foo",nil,nil)
=> #<GEPUB::Meta:0x00007fd26d2ac8c0 @parent=nil, @name="foo", @content=nil, @attributes={}, @refiners={}>
irb(main):003:0> m.to_s(nil)
Traceback (most recent call last):
       16: from /Users/maki/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/bundler-1.16.1/lib/bundler/friendly_errors.rb:122:in `with_friendly_errors'
       15: from /Users/maki/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/bundler-1.16.1/exe/bundle:30:in `block in <top (required)>'
       14: from /Users/maki/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/bundler-1.16.1/lib/bundler/cli.rb:18:in `start'
       13: from /Users/maki/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/bundler-1.16.1/lib/bundler/vendor/thor/lib/thor/base.rb:466:in `start'
       12: from /Users/maki/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/bundler-1.16.1/lib/bundler/cli.rb:27:in `dispatch'
       11: from /Users/maki/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/bundler-1.16.1/lib/bundler/vendor/thor/lib/thor.rb:387:in `dispatch'
       10: from /Users/maki/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/bundler-1.16.1/lib/bundler/vendor/thor/lib/thor/invocation.rb:126:in `invoke_command'
        9: from /Users/maki/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/bundler-1.16.1/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
        8: from /Users/maki/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/bundler-1.16.1/lib/bundler/cli.rb:424:in `exec'
        7: from /Users/maki/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/bundler-1.16.1/lib/bundler/cli/exec.rb:28:in `run'
        6: from /Users/maki/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/bundler-1.16.1/lib/bundler/cli/exec.rb:75:in `kernel_load'
        5: from /Users/maki/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/bundler-1.16.1/lib/bundler/cli/exec.rb:75:in `load'
        4: from /Users/maki/.rbenv/versions/2.5.0/bin/irb:11:in `<top (required)>'
        3: from (irb):3
        2: from /Users/maki/git/gepub/lib/gepub/meta.rb:146:in `to_s'
        1: from /Users/maki/git/gepub/lib/gepub/meta.rb:146:in `to_s'
ArgumentError (wrong number of arguments (given 1, expected 0))
irb(main):004:0> 
```

### after

```
$ bundle exec irb
irb(main):001:0> require "gepub"
=> true
irb(main):002:0> m=GEPUB::Meta.new("foo",nil,nil)
=> #<GEPUB::Meta:0x00007fb51442c838 @parent=nil, @name="foo", @content=nil, @attributes={}, @refiners={}>
irb(main):003:0> m.to_s(nil)
=> "#<GEPUB::Meta:0x00007fb51442c838>"
irb(main):004:0> 
```