### PR TITLE
fix error of `Metadata#date=`

### DIFF
--- a/lib/gepub/metadata.rb
+++ b/lib/gepub/metadata.rb
@@ -140,7 +140,11 @@ module GEPUB
       define_method(node+'=') {
         |content|
         send(node + "_clear")
-        add_metadata(node, content, nil)
+        if node == 'date'
+          add_date(content, nil)
+        else
+          add_metadata(node, content, nil)
+        end
       }
 
       next if ["identifier", "date", "creator", "contributor"].include?(node)

--- a/spec/metadata_spec.rb
+++ b/spec/metadata_spec.rb
@@ -153,6 +153,13 @@ describe GEPUB::Metadata do
       expect(metadata.date.to_s).to eq('2012-02-27T20:00:00Z')
     end
 
+    it 'should handle date with `date=` method and Time object' do
+      metadata = GEPUB::Metadata.new
+      a = Time.parse '2012-02-27 20:00:00 UTC'
+      metadata.date = a
+      expect(metadata.date.to_s).to eq('2012-02-27T20:00:00Z')
+    end
+
     it 'should handle date with Time object by content = ' do
       metadata = GEPUB::Metadata.new
       a = Time.parse '2012-02-27 20:00:00 UTC'


### PR DESCRIPTION
When I add a new spec like below (without fix in lib/gepub/metadata.rb), I got an error:

```
Failures:

  1) GEPUB::Metadata Generate New OPF should handle date with `date=` method and Time object
     Failure/Error: expect(metadata.date.to_s).to eq('2012-02-27T20:00:00Z')
     
       expected: "2012-02-27T20:00:00Z"
            got: "2012-02-27 20:00:00 UTC"
     
       (compared using ==)
     # ./spec/metadata_spec.rb:160:in `block (3 levels) in <top (required)>'

```