### PR TITLE
add_raw_content: return self as same as add_content

### DIFF
--- a/lib/gepub/item.rb
+++ b/lib/gepub/item.rb
@@ -110,6 +110,7 @@ module GEPUB
     def add_raw_content(data)
       @content = data
       guess_content_property
+      self
     end
 
     # add content form io or file to the item


### PR DESCRIPTION
With this patch, we can use method chaining like `Item#add_content`.