### PR TITLE
refactor: eval is too much to simple method call; so use __send__

### DIFF
--- a/lib/gepub/meta.rb
+++ b/lib/gepub/meta.rb
@@ -114,8 +114,14 @@ module GEPUB
         @attributes['id'] = id_pool.generate_key(:prefix => name) if @attributes['id'].nil?
       end
 
-      # using eval to parametarize Namespace and content.
-      eval "builder#{ ns.nil? || @name == 'meta' ? '' : '[ns]'}.#{@name}(@attributes.reject{|k,v| v.nil?}.merge(additional_attr)#{@content.nil? ? '' : ',  self.to_s'})"
+      # using __send__ to parametarize Namespace and content.
+      target = ns.nil? || @name == 'meta' ? builder : builder[ns]
+      attr = @attributes.reject{|k,v| v.nil?}.merge(additional_attr)
+      if @content.nil?
+        target.__send__(@name, attr)
+      else
+        target.__send__(@name, attr, self.to_s)
+      end
 
       if @refiners.size > 0 && opf_version.to_f >= 3.0
         additional_attr['refines'] = "##{@attributes['id']}"


### PR DESCRIPTION
IMHO, `eval`-ing embedded string with conditional operators is difficult to read and dangerous.  `__send__` is more clear to show what we do.