### PR TITLE
Fix multiple exceptions when saving an empty book

### DIFF
--- a/lib/gepub/book.rb
+++ b/lib/gepub/book.rb
@@ -266,7 +266,7 @@ EOF
     
     def nav_doc(title = 'Table of Contents')
       # handle cascaded toc
-      start_level = @toc && @toc[0][:level] || 1
+      start_level = @toc && !@toc.empty? && @toc[0][:level] || 1
       stacked_toc = {level: start_level, tocs: [] }
       @toc.inject(stacked_toc) do |current_stack, toc_entry|
         toc_entry_level = toc_entry[:level] || 1
@@ -428,7 +428,7 @@ EOF
           |_x,item|
           item.media_type == 'application/x-dtbncx+xml'
         }.size == 0
-          if (@toc.size == 0)
+          if (@toc.size == 0 && !@package.spine.itemref_list.empty?)
             @toc << { :item => @package.manifest.item_list[@package.spine.itemref_list[0].idref] }
           end
           add_item('toc.ncx', id: 'ncx', content: StringIO.new(ncx_xml))

--- a/lib/gepub/metadata.rb
+++ b/lib/gepub/metadata.rb
@@ -171,7 +171,7 @@ module GEPUB
     end
 
     def identifier_by_id(id)
-      @content_nodes['identifier'].each {
+      (@content_nodes['identifier'] || []).each {
         |x|
         return x.content if x['id'] == id
       }

--- a/spec/gepub_spec.rb
+++ b/spec/gepub_spec.rb
@@ -40,7 +40,7 @@ end
 
 describe GEPUB::Book do
   before do
-    @book = GEPUB::Book.new('OEPBS/package.opf') 
+    @book = GEPUB::Book.new('OEPBS/package.opf')
     @book.title = 'thetitle'
     @book.creator = "theauthor"
     @book.contributor = "contributors contributors!"
@@ -270,6 +270,15 @@ EOF
     end
   end
 
+  it 'should produce empty EPUB2 book' do
+    @book = GEPUB::Book.new('OEPBS/package.opf', { 'version' => '2.0'})
+    @book.generate_epub_stream
+  end
+
+  it 'should produce empty EPUB3 book' do
+    @book = GEPUB::Book.new('OEPBS/package.opf', { 'version' => '3.0'})
+    @book.generate_epub_stream
+  end
 
   it 'should produce deterministic output when lastmodified is specified' do
     epubname1 = File.join(File.dirname(__FILE__), 'testepub1.epub')


### PR DESCRIPTION
While empty book is not a very useful thing, we can easily avoid `NoMethodError: undefined method '<whatever>' for nil:NilClass` with some minor fixes.