### PR TITLE
Replace tab with space

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,5 @@
+AllCops:
+  DisabledByDefault: true
+
+Style/Tab:
+  Enabled: true

--- a/Rakefile
+++ b/Rakefile
@@ -14,7 +14,7 @@ end
 
 # also generates 'lib/gepub/book_add_item.rb' 
 file 'lib/gepub/metadata_add.rb' => 'tools/generate_function.rb' do
-	sh %Q(ruby tools/generate_function.rb)
+  sh %Q(ruby tools/generate_function.rb)
 end
 
 desc 'auto generate code'

--- a/gepub.gemspec
+++ b/gepub.gemspec
@@ -20,4 +20,5 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "rubyzip", "> 1.1.1", "< 2.4"
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec"
+  s.add_development_dependency "rubocop"
 end

--- a/lib/gepub/metadata_add.rb
+++ b/lib/gepub/metadata_add.rb
@@ -1,5 +1,5 @@
 module GEPUB
-	class Metadata
+  class Metadata
     CONTENT_NODE_LIST = ['identifier', 'title', 'language', 'contributor', 'creator', 'coverage', 'date','description','format','publisher','relation','rights','source','subject','type'].each {
       |node|
       define_method(node + '_list') { @content_nodes[node].dup.sort_as_meta }
@@ -14,7 +14,7 @@ module GEPUB
 
       define_method(node, ->(content=UNASSIGNED, deprecated_id=nil, id:nil,
                              title_type: nil,identifier_type: nil,display_seq: nil,file_as: nil,group_position: nil,role: nil,
-														 lang: nil, alternates: {}) {
+                             lang: nil, alternates: {}) {
                       if unassigned?(content)
                         get_first_node(node)
                       else
@@ -48,7 +48,7 @@ module GEPUB
 
     def add_title(content, deprecated_id = nil, deprecated_title_type = nil, id: nil,
                   title_type: nil,identifier_type: nil,display_seq: nil,file_as: nil,group_position: nil,role: nil,
-									lang: nil, alternates: {})
+                  lang: nil, alternates: {})
       if deprecated_id
         warn 'second argument for add_title is deprecated. use id: instead'
         id = deprecated_id
@@ -58,15 +58,15 @@ module GEPUB
         title_type = deprecated_title_type
       end
       meta = add_metadata('title', content, id: id, 
-			                    title_type: title_type,identifier_type: identifier_type,display_seq: display_seq,file_as: file_as,group_position: group_position,role: role,
-													lang: lang, alternates: alternates)
+                          title_type: title_type,identifier_type: identifier_type,display_seq: display_seq,file_as: file_as,group_position: group_position,role: role,
+                          lang: lang, alternates: alternates)
       yield meta if block_given?
       meta
     end
 
     def add_person(name, content, deprecated_id = nil, deprecated_role = nil, id: nil,
                   title_type: nil,identifier_type: nil,display_seq: nil,file_as: nil,group_position: nil,role: nil,
-									lang: nil, alternates: {})
+                  lang: nil, alternates: {})
       if deprecated_id
         warn 'second argument for add_person is deprecated. use id: instead'
         id = deprecated_id
@@ -76,15 +76,15 @@ module GEPUB
         role = deprecated_role
       end
       meta = add_metadata(name, content, id: id,
-			                    title_type: title_type,identifier_type: identifier_type,display_seq: display_seq,file_as: file_as,group_position: group_position,role: role,
-													lang: lang, alternates: alternates)
+                          title_type: title_type,identifier_type: identifier_type,display_seq: display_seq,file_as: file_as,group_position: group_position,role: role,
+                          lang: lang, alternates: alternates)
       yield meta if block_given?
       meta
     end
 
     def add_creator(content, deprecated_id = nil, deprecated_role = nil, id: nil, 
                     title_type: nil,identifier_type: nil,display_seq: nil,file_as: nil,group_position: nil,role: nil,
-  									lang: nil, alternates: {}) 
+                    lang: nil, alternates: {}) 
       if deprecated_id
         warn 'second argument for add_creator is deprecated. use id: instead'
         id = deprecated_id
@@ -93,17 +93,17 @@ module GEPUB
         warn 'third argument for add_creator is deprecated. use role: instead'
         role = deprecated_role
       end
-			role = 'aut' if role.nil?
+      role = 'aut' if role.nil?
       meta = add_person('creator', content, id: id,
-			                    title_type: title_type,identifier_type: identifier_type,display_seq: display_seq,file_as: file_as,group_position: group_position,role: role,
-													lang: lang, alternates: alternates)
+                          title_type: title_type,identifier_type: identifier_type,display_seq: display_seq,file_as: file_as,group_position: group_position,role: role,
+                          lang: lang, alternates: alternates)
       yield meta if block_given?
       meta
     end
 
     def add_contributor(content, deprecated_id = nil, deprecated_role = nil, id: nil,
                         title_type: nil,identifier_type: nil,display_seq: nil,file_as: nil,group_position: nil,role: nil,
-											  lang: nil, alternates: {}) 
+                        lang: nil, alternates: {}) 
       if deprecated_id
         warn 'second argument for add_contributor is deprecated. use id: instead'
         id = deprecated_id
@@ -113,30 +113,30 @@ module GEPUB
         role = deprecated_role
       end
       meta = add_person('contributor', content, id: id, 
-			                  title_type: title_type,identifier_type: identifier_type,display_seq: display_seq,file_as: file_as,group_position: group_position,role: role,
-												lang: lang, alternates: alternates)
+                        title_type: title_type,identifier_type: identifier_type,display_seq: display_seq,file_as: file_as,group_position: group_position,role: role,
+                        lang: lang, alternates: alternates)
       yield meta if block_given?
       meta
     end
 
-		def add_metadata(name, content, id: nil, itemclass: Meta,
-		title_type: nil,identifier_type: nil,display_seq: nil,file_as: nil,group_position: nil,role: nil,
-		lang: nil, alternates: {}
-		)
-			meta = add_metadata_internal(name, content, id: id, itemclass: itemclass)
+    def add_metadata(name, content, id: nil, itemclass: Meta,
+    title_type: nil,identifier_type: nil,display_seq: nil,file_as: nil,group_position: nil,role: nil,
+    lang: nil, alternates: {}
+    )
+      meta = add_metadata_internal(name, content, id: id, itemclass: itemclass)
       [{ value: title_type, name: 'title-type'},{ value: identifier_type, name: 'identifier-type'},{ value: display_seq, name: 'display-seq'},{ value: file_as, name: 'file-as'},{ value: group_position, name: 'group-position'},{ value: role, name: 'role'}].each do |refiner|
-				if refiner[:value]
-				  meta.refine(refiner[:name], refiner[:value])
-				end
-	    end	
-			if lang
-			  meta.lang = lang
-			end
-			if alternates
-			  meta.add_alternates alternates
-			end
+        if refiner[:value]
+          meta.refine(refiner[:name], refiner[:value])
+        end
+      end  
+      if lang
+        meta.lang = lang
+      end
+      if alternates
+        meta.add_alternates alternates
+      end
       yield meta if block_given?
-			meta
-		end
-	end
+      meta
+    end
+  end
 end

--- a/spec/example_spec.rb
+++ b/spec/example_spec.rb
@@ -128,7 +128,7 @@ describe 'GEPUB usage' do
       book.generate_epub(epubname)
       epubcheck(epubname)
     end
-		
+    
     it 'should generate simple EPUB3 with landmarks' do
       book = GEPUB::Book.new
       book.primary_identifier('http:/example.jp/bookid_in_url', 'BookID', 'URL')
@@ -162,8 +162,8 @@ describe 'GEPUB usage' do
       
       # within ordered block, add_item will be added to spine.
       book.ordered {
-				book.add_item('text/cover.xhtml').add_content(StringIO.new('<html xmlns="http://www.w3.org/1999/xhtml"><head><title>cover</title></head><body><h1>the book title</h1><img src="../img/image1.jpg" /></body></html>')).landmark(type: 'cover', title: '表紙')
-				book.add_item('text/chap1.xhtml').add_content(StringIO.new('<html xmlns="http://www.w3.org/1999/xhtml"><head><title>c1</title></head><body><p>the first page</p></body></html>')).toc_text('Chapter 1').landmark(type: 'bodymatter', title: '本文')
+        book.add_item('text/cover.xhtml').add_content(StringIO.new('<html xmlns="http://www.w3.org/1999/xhtml"><head><title>cover</title></head><body><h1>the book title</h1><img src="../img/image1.jpg" /></body></html>')).landmark(type: 'cover', title: '表紙')
+        book.add_item('text/chap1.xhtml').add_content(StringIO.new('<html xmlns="http://www.w3.org/1999/xhtml"><head><title>c1</title></head><body><p>the first page</p></body></html>')).toc_text('Chapter 1').landmark(type: 'bodymatter', title: '本文')
         book.add_item('text/chap1-1.xhtml').add_content(StringIO.new('<html xmlns="http://www.w3.org/1999/xhtml"><head><title>c2</title></head><body><p>the second page</p></body></html>')) # do not appear on table of contents
         book.add_item('text/chap2.xhtml').add_content(StringIO.new('<html xmlns="http://www.w3.org/1999/xhtml"><head><title>c3</title></head><body><p>the third page</p></body></html>')).toc_text('Chapter 2')
       }
@@ -173,7 +173,7 @@ describe 'GEPUB usage' do
       xml = Nokogiri::XML::Document.parse book.nav_doc
 
       # check toc
-			tocs =  xml.xpath("//xmlns:nav[@epub:type='toc']/xmlns:ol/xmlns:li") 
+      tocs =  xml.xpath("//xmlns:nav[@epub:type='toc']/xmlns:ol/xmlns:li") 
       expect(tocs.size).to eq 2
       expect(tocs[0].content.strip).to eq 'Chapter 1'
       expect(tocs[1].content.strip).to eq 'Chapter 2'

--- a/tools/generate_function.rb
+++ b/tools/generate_function.rb
@@ -35,7 +35,7 @@ require_relative '../lib/gepub/dsl_util.rb'
 require_relative '../lib/gepub/meta.rb'
 
 refiners = GEPUB::Meta::REFINERS.map do |refiner|
-	refiner.sub('-', '_')
+  refiner.sub('-', '_')
 end
 
 refiners_arguments_string = refiners.map { |refiner| "#{refiner}: nil" }.join(',')


### PR DESCRIPTION
Many files have a mix of space and tab characters, making it confusing to contribute. I've added a rubocop rule which checks against tab usage.

Also, could rubocop be added to Github Action so it is always checked for each PR? Thanks!