### PR TITLE
Speedup gems install on GH-Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,9 +21,7 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby }}
     - name: setup gems
-      run: |
-        gem install bundler
-        bundle install
+      run: bundle install --jobs 4 --retry 3
     - name: run test and publish code coverage
       if: runner.os == 'Linux' && matrix.ruby == '2.7' && env.CC_TEST_REPORTER_ID != ''
       uses: paambaati/codeclimate-action@v2.3.0


### PR DESCRIPTION
1. Stop installing Bundler manually. setup-ruby already does that
2. Use multiple jobs for `bundle install`