### PR TITLE
Enable CI on Ruby 2.7 on Windows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,11 +6,6 @@ jobs:
       matrix:
         ruby: [2.4, 2.5, 2.6, 2.7, jruby]
         platform: [ubuntu-latest, macos-latest, windows-latest]
-        exclude:
-          # TODO: https://github.com/sparklemotion/nokogiri/issues/1961
-          # exclude windows with ruby 2.7 ; nokogiri is not supported for the present
-          - ruby: 2.7
-            platform: windows-latest
     runs-on: ${{ matrix.platform }}
     env:
       CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}


### PR DESCRIPTION
Nokogiri 1.10.10 added precompiled Windows libs for Ruby 2.7