### PR TITLE
Include htm5 doctype in the generated nav file

### DIFF
--- a/lib/gepub/book.rb
+++ b/lib/gepub/book.rb
@@ -316,6 +316,9 @@ EOF
       # build nav
       builder = Nokogiri::XML::Builder.new {
         |doc|
+        unless version.to_f < 3.0
+          doc.doc.create_internal_subset('html', nil, nil )
+        end
         doc.html('xmlns' => "http://www.w3.org/1999/xhtml",'xmlns:epub' => "http://www.idpf.org/2007/ops") {
           doc.head {
             doc.title title


### PR DESCRIPTION
Epub3 uses xhtml5 for content files. Although the doctype is not mandatory, it’s better to include it. Editors like Sigil will complain that an epub contains files that not well-formed without the doctype.

I’ve therefore add a version check so it’s only inserted for epub v3.0 or greater.