### PR TITLE
Make inspect console friendly

### DIFF
--- a/lib/gepub.rb
+++ b/lib/gepub.rb
@@ -4,6 +4,7 @@ end if RUBY_VERSION < "2.7" && !(defined? ruby2_keywords)
 require 'gepub/version'
 require 'gepub/dsl_util'
 require 'gepub/xml_util'
+require 'gepub/inspect_mixin'
 require 'gepub/meta'
 require 'gepub/datemeta'
 require 'gepub/meta_array'

--- a/lib/gepub/bindings.rb
+++ b/lib/gepub/bindings.rb
@@ -3,6 +3,8 @@ require 'nokogiri'
 module GEPUB
   class Bindings
     include XMLUtil
+    include InspectMixin
+
     class MediaType
       attr_accessor :handler, :media_type
       def initialize(handler, media_type)

--- a/lib/gepub/book.rb
+++ b/lib/gepub/book.rb
@@ -79,6 +79,8 @@ module GEPUB
   # set page-proression-direction attribute to spine.
 
   class Book
+    include InspectMixin
+
     MIMETYPE='mimetype'
     MIMETYPE_CONTENTS='application/epub+zip'
     CONTAINER='META-INF/container.xml'

--- a/lib/gepub/inspect_mixin.rb
+++ b/lib/gepub/inspect_mixin.rb
@@ -1,0 +1,26 @@
+module GEPUB
+  module InspectMixin
+    def inspect
+      result = instance_variables.each
+        .with_object({}) { |name, h| h[name] = instance_variable_get(name) }
+        .reject { |name, value| value.nil? }
+        .map { |name, value|
+          case value
+          when true, false, Symbol, Numeric, Array, Hash
+            "#{name}=#{value.inspect}"
+          when String
+            if value.length > 80
+              "#{name}=(omitted)"
+            else
+              "#{name}=#{value.inspect}"
+            end
+          else
+            "#{name}=#<#{value.class.name}>"
+          end
+        }
+        .join(' ')
+
+      "#<#{self.class.name} " + result + '>'
+    end
+  end
+end

--- a/lib/gepub/item.rb
+++ b/lib/gepub/item.rb
@@ -6,6 +6,8 @@ module GEPUB
   # #id, #id=, #set_id, #href, #href=, #set_href, #media_type, #media_type=, #set_media_type,
   # #fallback, #fallback=, #set_fallback, #media_overlay, #media_overlay=, #set_media_overlay
   class Item
+    include InspectMixin
+
     attr_accessor :content
     def self.create(parent, attributes = {})
       Item.new(attributes['id'], attributes['href'], attributes['media-type'], parent,

--- a/lib/gepub/manifest.rb
+++ b/lib/gepub/manifest.rb
@@ -3,6 +3,8 @@ require 'nokogiri'
 module GEPUB
   class Manifest
     include XMLUtil
+    include InspectMixin
+
     attr_accessor :opf_version
     def self.parse(manifest_xml, opf_version = '3.0', id_pool = Package::IDPool.new)
       Manifest.new(opf_version, id_pool) {

--- a/lib/gepub/metadata.rb
+++ b/lib/gepub/metadata.rb
@@ -18,6 +18,8 @@ module GEPUB
       end
     end
     include XMLUtil, DSLUtil
+    include InspectMixin
+
     attr_accessor :opf_version
     # parse metadata element. metadata_xml should be Nokogiri::XML::Node object.
     def self.parse(metadata_xml, opf_version = '3.0', id_pool = Package::IDPool.new)

--- a/lib/gepub/package.rb
+++ b/lib/gepub/package.rb
@@ -6,6 +6,8 @@ module GEPUB
   # Holds data in opf file.
   class Package
     include XMLUtil, DSLUtil
+    include InspectMixin
+
     extend Forwardable
     attr_accessor :path, :metadata, :manifest, :spine, :bindings, :epub_backward_compat, :contents_prefix, :prefixes 
     def_delegators :@manifest, :item_by_href

--- a/lib/gepub/spine.rb
+++ b/lib/gepub/spine.rb
@@ -3,6 +3,8 @@ require 'nokogiri'
 module GEPUB
   class Spine
     include XMLUtil
+    include InspectMixin
+
     attr_accessor :opf_version
     class Itemref
       def self.create(parent, attributes = {})

--- a/tools/generate_function.rb
+++ b/tools/generate_function.rb
@@ -1,3 +1,4 @@
+require_relative '../lib/gepub/inspect_mixin.rb'
 require_relative '../lib/gepub/item.rb'
 attrs = GEPUB::Item::ATTRIBUTES.select do |attr|
   attr != 'href'


### PR DESCRIPTION
When learning the library, often ruby IRB console would print never-ending object inspect message, because object attribute contains books' content/ binary data. This made learning/debugging difficult.

I modified the own inspect method:

- Omit long strings
- Print only class name for non standard types

For example now it can print

```log
#<GEPUB::Item 
  @attributes={"id"=>"core.css", "href"=>"css/core.css", "media-type"=>"text/css"} 
  @parent=#<GEPUB::Manifest> 
  @content=(omitted)>
```

Do you think this is okay? Thanks.