### PR TITLE
Correct indentation to silence Ruby warnings

### DIFF
--- a/lib/gepub/metadata_add.rb
+++ b/lib/gepub/metadata_add.rb
@@ -138,7 +138,7 @@ module GEPUB
         meta.add_alternates alternates
       end
       yield meta if block_given?
-          meta
-      end
+      meta
     end
+  end
 end

--- a/tools/generate_function.rb
+++ b/tools/generate_function.rb
@@ -189,9 +189,9 @@ module GEPUB
         meta.add_alternates alternates
       end
       yield meta if block_given?
-          meta
-      end
+      meta
     end
+  end
 end
 EOF
 


### PR DESCRIPTION
```
warning: mismatched indentations at 'end' with 'def' at 124
warning: mismatched indentations at 'end' with 'class' at 4
```