### PR TITLE
Close entries streams after read on parse

### DIFF
--- a/lib/gepub/book.rb
+++ b/lib/gepub/book.rb
@@ -384,7 +384,7 @@ EOF
       package = nil
       zip_file.each do |entry|
         if !entry.directory?
-          files[entry.name] = zip_file.read(entry)
+          files[entry.name] = entry.get_input_stream(&:read)
           case entry.name
           when MIMETYPE then
             if files[MIMETYPE] != MIMETYPE_CONTENTS

--- a/lib/gepub/book.rb
+++ b/lib/gepub/book.rb
@@ -94,15 +94,15 @@ module GEPUB
       doc.css("#{defaultns}|rootfiles > #{defaultns}|rootfile")[0]['full-path']
     end
 
-    # Parses existing EPUB2/EPUB3 files from an IO object, and creates new Book object.
+    # Parses existing EPUB2/EPUB3 files from an IO object or a file path and creates new Book object.
     #   book = self.parse(File.new('some.epub'))
 
-    def self.parse(io)
+    def self.parse(path_or_io)
       files = {}
       package = nil
       package_path = nil
       book = nil
-      Zip::File.open_buffer(io) do
+      Zip::File.open(path_or_io) do
         |zip_file|
         package, package_path = parse_container(zip_file, files)
         check_consistency_of_package(package, package_path)

--- a/spec/book_spec.rb
+++ b/spec/book_spec.rb
@@ -402,6 +402,15 @@ describe GEPUB::Book do
        expect(book.items.size).to eq 3
       end
      end
+
+     context 'file path' do
+       it 'loads book and returns GEPUB::Book object' do
+         filepath = File.join(File.dirname(__FILE__), 'fixtures', 'testdata', 'wasteland-20120118.epub')
+         book = GEPUB::Book.parse(filepath)
+         expect(book).to be_instance_of GEPUB::Book
+         expect(book.items.size).to eq 6
+       end
+     end
     end
   end
 end

--- a/spec/gepub_spec.rb
+++ b/spec/gepub_spec.rb
@@ -79,8 +79,7 @@ EOF
     end
 
     after do
-      # workaround; rubyzip opened files could not be deleted with remove_entry_secure on windows.
-      FileUtils.rm_rf @tempdir
+      FileUtils.remove_entry_secure @tempdir
     end
     
     it "should have title"  do


### PR DESCRIPTION
This PR closes entry streams by utilizing a block version of [get_input_stream](https://www.rubydoc.info/gems/rubyzip/2.3.2/Zip/Entry#get_input_stream-instance_method) which takes care of closing the stream and switches `Zip::File.open` from `Zip::File.open_buffer`, because `.open_buffer` causes issues on windows in some versions of rubyzip, see https://github.com/rubyzip/rubyzip/commit/ef89a62b70d0b0c43a9579d414d5a917fef0cdc3 and https://github.com/rubyzip/rubyzip/commit/cdef4a518738c249c4843c34e9c8bba1c9e99c89 (output stream may seem irrelevant, but open_buffer writes data to output stream in some cases https://www.rubydoc.info/gems/rubyzip/2.3.2/Zip%2FFile.open_buffer).

Fixes https://github.com/skoji/gepub/issues/141