### PR TITLE
Centralize spec_helper loading

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,1 @@
+--require spec_helper

--- a/spec/bindings_spec.rb
+++ b/spec/bindings_spec.rb
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-require File.dirname(__FILE__) + '/spec_helper.rb'
 require 'rubygems'
 require 'nokogiri'
 

--- a/spec/book_spec.rb
+++ b/spec/book_spec.rb
@@ -1,4 +1,3 @@
-require File.dirname(__FILE__) + '/spec_helper.rb'
 require 'rubygems'
 require 'nokogiri'
 

--- a/spec/builder_spec.rb
+++ b/spec/builder_spec.rb
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-require File.dirname(__FILE__) + '/spec_helper.rb'
 require 'rubygems'
 describe GEPUB::Builder do
   context 'metadata generating' do

--- a/spec/example_spec.rb
+++ b/spec/example_spec.rb
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-require File.dirname(__FILE__) + '/spec_helper.rb'
 require 'rubygems'
 
 describe 'GEPUB usage' do

--- a/spec/gepub_deprectad_api_spec.rb
+++ b/spec/gepub_deprectad_api_spec.rb
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-require File.dirname(__FILE__) + '/spec_helper.rb'
 require 'rubygems'
 require 'nokogiri'
 

--- a/spec/gepub_spec.rb
+++ b/spec/gepub_spec.rb
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-require File.dirname(__FILE__) + '/spec_helper.rb'
 require 'rubygems'
 require 'nokogiri'
 

--- a/spec/manifest_spec.rb
+++ b/spec/manifest_spec.rb
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-require File.dirname(__FILE__) + '/spec_helper.rb'
 require 'rubygems'
 require 'nokogiri'
 

--- a/spec/metadata_spec.rb
+++ b/spec/metadata_spec.rb
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-require File.dirname(__FILE__) + '/spec_helper.rb'
 require 'rubygems'
 require 'nokogiri'
 

--- a/spec/package_spec.rb
+++ b/spec/package_spec.rb
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-require File.dirname(__FILE__) + '/spec_helper.rb'
 require 'rubygems'
 require 'nokogiri'
 

--- a/spec/spine_spec.rb
+++ b/spec/spine_spec.rb
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-require File.dirname(__FILE__) + '/spec_helper.rb'
 require 'rubygems'
 require 'nokogiri'
 


### PR DESCRIPTION
Remove noise in all the specification files by importing the spec_helper centrally through .rspec config