### PR TITLE
Generalize temporary directory handling

### DIFF
--- a/spec/example_spec.rb
+++ b/spec/example_spec.rb
@@ -6,15 +6,8 @@ describe 'GEPUB usage' do
   context 'On using Builder' do
   end
   
-  context 'On generating EPUB' do
-    before do
-      @tempdir = Dir.mktmpdir
-    end
+  context 'On generating EPUB', :uses_temporary_directory do
 
-    after do
-      FileUtils.remove_entry_secure @tempdir
-    end
-    
     it 'should generate simple EPUB3 with Builder and buffer' do
       workdir = File.join(File.dirname(__FILE__),  'fixtures', 'testdata')
       builder = GEPUB::Builder.new {
@@ -41,9 +34,9 @@ describe 'GEPUB usage' do
           }
         }
       }
-      epubname = File.join(@tempdir, 'example_test_with_builder_buffer.epub')
-      File.open(epubname, 'wb') { |io| io.write builder.generate_epub_stream.string }
-      epubcheck(epubname)
+      epub_file = @temporary_directory / 'example_test_with_builder_buffer.epub'
+      epub_file.open('wb') { |io| io.write builder.generate_epub_stream.string }
+      epubcheck(epub_file)
     end
 
     it 'should generate simple EPUB3 with Builder' do
@@ -72,9 +65,9 @@ describe 'GEPUB usage' do
           }
         }
       }
-      epubname = File.join(@tempdir, 'example_test_with_builder.epub')
-      builder.generate_epub(epubname)
-      epubcheck(epubname)
+      epub_file = @temporary_directory / 'example_test_with_builder.epub'
+      builder.generate_epub(epub_file)
+      epubcheck(epub_file)
     end
 
     it 'should generate simple EPUB3 with rather complicated matadata' do
@@ -114,9 +107,9 @@ describe 'GEPUB usage' do
         book.add_item('text/chap1-1.xhtml').add_content(StringIO.new('<html xmlns="http://www.w3.org/1999/xhtml"><head><title>c2</title></head><body><p>the second page</p></body></html>')) # do not appear on table of contents
         book.add_item('text/chap2.xhtml').add_content(StringIO.new('<html xmlns="http://www.w3.org/1999/xhtml"><head><title>c3</title></head><body><p>the third page</p></body></html>')).toc_text('Chapter 2')
       }
-      epubname = File.join(@tempdir, 'example_test.epub')
-      book.generate_epub(epubname)
-      epubcheck(epubname)
+      epub_file = @temporary_directory / 'example_test.epub'
+      book.generate_epub(epub_file)
+      epubcheck(epub_file)
     end
 
     it 'should generate simple EPUB3 with some nil metadata' do
@@ -132,9 +125,9 @@ describe 'GEPUB usage' do
         item.add_content StringIO.new('<html xmlns="http://www.w3.org/1999/xhtml"><head><title>c1</title></head><body><p>the first page</p></body></html>')
       end
 
-      epubname = File.join(@tempdir, 'example_test.epub')
-      book.generate_epub(epubname)
-      epubcheck(epubname)
+      epub_file = @temporary_directory / 'example_test.epub'
+      book.generate_epub(epub_file)
+      epubcheck(epub_file)
     end
     
     it 'should generate simple EPUB3 with landmarks' do
@@ -175,7 +168,7 @@ describe 'GEPUB usage' do
         book.add_item('text/chap1-1.xhtml').add_content(StringIO.new('<html xmlns="http://www.w3.org/1999/xhtml"><head><title>c2</title></head><body><p>the second page</p></body></html>')) # do not appear on table of contents
         book.add_item('text/chap2.xhtml').add_content(StringIO.new('<html xmlns="http://www.w3.org/1999/xhtml"><head><title>c3</title></head><body><p>the third page</p></body></html>')).toc_text('Chapter 2')
       }
-      epubname = File.join(@tempdir, 'example_test.epub')
+      epub_file = @temporary_directory / 'example_test.epub'
 
       # check nav doc
       xml = Nokogiri::XML::Document.parse book.nav_doc
@@ -193,8 +186,8 @@ describe 'GEPUB usage' do
       expect(landmarks[0]['href']).to eq 'text/cover.xhtml'
       expect(landmarks[1]['epub:type']).to eq 'bodymatter'
       expect(landmarks[1]['href']).to eq 'text/chap1.xhtml'
-      book.generate_epub(epubname)
-      epubcheck(epubname)
+      book.generate_epub(epub_file)
+      epubcheck(epub_file)
     end
   end
 end

--- a/spec/gepub_deprectad_api_spec.rb
+++ b/spec/gepub_deprectad_api_spec.rb
@@ -75,11 +75,6 @@ describe GEPUB::Book do
 </html>
 EOF
     item3 = @book.add_ordered_item('text/nav.xhtml', StringIO.new(nav_string), 'nav').add_property('nav')
-    @tempdir = Dir.mktmpdir
-  end
-
-  after do
-    FileUtils.remove_entry_secure @tempdir
   end
 
   it "should have title"  do
@@ -159,22 +154,23 @@ EOF
     expect(meta['content']).to eq(item.itemid)        
   end
 
-  it "should generate correct epub" do
-    epubname = File.join(@tempdir, 'testepub.epub')
-    @book.generate_epub(epubname)
-    epubcheck(epubname)
+  it "should generate correct epub", :uses_temporary_directory do
+    epub_file = @temporary_directory / 'testepub.epub'
+    @book.generate_epub(epub_file)
+    epubcheck(epub_file)
   end
-  it "should generate correct epub with buffer" do
-    epubname = File.join(@tempdir, 'testepub_buf.epub')
-    File.open(epubname, 'wb') {
+
+  it "should generate correct epub with buffer", :uses_temporary_directory do
+    epub_file = @temporary_directory / 'testepub_buf.epub'
+    File.open(epub_file, 'wb') {
       |io|
       io.write @book.generate_epub_stream.string
     }
-    epubcheck(epubname)
+    epubcheck(epub_file)
   end
 
-  it "should generate correct epub2.0" do
-    epubname = File.join(@tempdir, 'testepub2.epub')
+  it "should generate correct epub2.0", :uses_temporary_directory do
+    epub_file = @temporary_directory / 'testepub2.epub'
     @book = GEPUB::Book.new('OEPBS/package.opf', { 'version' => '2.0'} ) 
     @book.title = 'thetitle'
     @book.creator = "theauthor"
@@ -190,18 +186,18 @@ EOF
                                    StringIO.new('<html xmlns="http://www.w3.org/1999/xhtml"><head><title>c2</title></head><body><p>second page, whith is test chapter.</p></body></html>'),
                                    'c2')
     item2.toc_text 'test chapter'
-    @book.generate_epub(epubname)
-    epubcheck(epubname)
+    @book.generate_epub(epub_file)
+    epubcheck(epub_file)
   end
-  it 'should generate epub with extra file' do
-    epubname = File.join(@tempdir, 'testepub3.epub')
+  it 'should generate epub with extra file', :uses_temporary_directory do
+    epub_file = @temporary_directory / 'testepub3.epub'
     @book.add_optional_file('META-INF/foobar.xml', StringIO.new('<foo></foo>'))
-    @book.generate_epub(epubname)
-    epubcheck(epubname)
+    @book.generate_epub(epub_file)
+    epubcheck(epub_file)
   end
 
-  it 'should generate valid EPUB when @toc is empty' do
-    epubname = File.join(@tempdir, 'testepub4.epub')
+  it 'should generate valid EPUB when @toc is empty', :uses_temporary_directory do
+    epub_file = @temporary_directory / 'testepub4.epub'
     @book = GEPUB::Book.new('OEPBS/package.opf', { 'version' => '3.0'} ) 
     @book.title = 'thetitle'
     @book.creator = "theauthor"
@@ -216,8 +212,8 @@ EOF
     item2 = @book.add_ordered_item('text/barbar.xhtml',
                                    StringIO.new('<html xmlns="http://www.w3.org/1999/xhtml"><head><title>c2</title></head><body><p>second page, whith is test chapter.</p></body></html>'),
                                    'c2')
-    @book.generate_epub(epubname)
-    epubcheck(epubname)
+    @book.generate_epub(epub_file)
+    epubcheck(epub_file)
 
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -39,7 +39,14 @@ RSpec.configure do |config|
     end
     expect(stdout).to include("No errors or warnings detected.")
   end
-  
+
+  config.around(:example, :uses_temporary_directory) do |example|
+    @temporary_directory = Pathname(Dir.mktmpdir("gepub_spec"))    
+    example.run
+  ensure
+    @temporary_directory.rmtree
+  end
+
 end
 
 require 'rspec/core/formatters/base_text_formatter'


### PR DESCRIPTION
Generalize the temporary directory handling in specification by using example tagging and a centrally provided around(:example) filter that creates a Pathname based temporary directory and ensures removal after execution.