### PR TITLE
Access spec fixtures less noisy through Pathname

### DIFF
--- a/spec/bindings_spec.rb
+++ b/spec/bindings_spec.rb
@@ -6,7 +6,7 @@ require 'nokogiri'
 describe GEPUB::Bindings do
   context 'parse existing opf' do
     before do
-      @bindings = GEPUB::Package.parse_opf(File.open(File.dirname(__FILE__) + '/fixtures/testdata/test_with_bindings.opf'), '/package.opf').instance_eval{ @bindings }
+      @bindings = GEPUB::Package.parse_opf(@fixtures_directory / 'testdata/test_with_bindings.opf', '/package.opf').instance_eval{ @bindings }
     end
     it 'should be parsed' do
       expect(@bindings.media_types.size).to eq(2)

--- a/spec/book_spec.rb
+++ b/spec/book_spec.rb
@@ -375,8 +375,8 @@ describe GEPUB::Book do
     describe '.parse' do
      context 'IO Object' do
       it 'loads book and returns GEPUB::Book object' do
-       filehandle = File.new(File.dirname(__FILE__) + '/fixtures/testdata/wasteland-20120118.epub')
-       book = GEPUB::Book.parse(filehandle)
+       file = @fixtures_directory / 'testdata/wasteland-20120118.epub'
+       book = GEPUB::Book.parse(file)
        expect(book).to be_instance_of GEPUB::Book
        expect(book.items.size).to eq 6
        expect(book.items['t1'].href).to eq 'wasteland-content.xhtml'
@@ -390,14 +390,14 @@ describe GEPUB::Book do
        expect(book.spine_items[0].href).to eq 'wasteland-content.xhtml'
       end
       it 'loads non-latin EPUB as UTF-8' do
-       filehandle = File.new(File.dirname(__FILE__) + '/fixtures/testdata/lemon.epub')
-       book = GEPUB::Book.parse(filehandle)
+       file = @fixtures_directory / 'testdata/lemon.epub'
+       book = GEPUB::Book.parse(file)
        expect(book.items['p-001'].href).to eq 'xhtml/p-001.xhtml'
        expect(book.items['p-001'].content.encoding).to eq Encoding::UTF_8       
       end
       it 'reads EPUB with streamed entries' do
-       filehandle = File.new(File.dirname(__FILE__) + '/fixtures/testdata/streamed_item.epub')
-       book = GEPUB::Book.parse(filehandle)
+       file = @fixtures_directory / 'testdata/streamed_item.epub'
+       book = GEPUB::Book.parse(file)
        expect(book).to be_instance_of GEPUB::Book
        expect(book.items.size).to eq 3
       end
@@ -405,8 +405,8 @@ describe GEPUB::Book do
 
      context 'file path' do
        it 'loads book and returns GEPUB::Book object' do
-         filepath = File.join(File.dirname(__FILE__), 'fixtures', 'testdata', 'wasteland-20120118.epub')
-         book = GEPUB::Book.parse(filepath)
+         file = @fixtures_directory / 'testdata/wasteland-20120118.epub'
+         book = GEPUB::Book.parse(file)
          expect(book).to be_instance_of GEPUB::Book
          expect(book.items.size).to eq 6
        end

--- a/spec/gepub_spec.rb
+++ b/spec/gepub_spec.rb
@@ -245,10 +245,10 @@ EOF
     end
 
     it 'should generate parsed and generated EPUB with renewed lastmodified' do
-      originalfile = File.join(File.dirname(__FILE__), 'fixtures/testdata/wasteland-20120118.epub')
+      original_file = @fixtures_directory / 'testdata/wasteland-20120118.epub'
       epubname = File.join(@tempdir, 'testepub.epub')    
 
-      original_book = File.open(originalfile) do |f|
+      original_book = File.open(original_file) do |f|
         GEPUB::Book.parse(f)
       end
       original_lastmodified = original_book.lastmodified.content
@@ -262,13 +262,11 @@ EOF
     end
 
     it 'should generate parsed and generated EPUB with newly set lastmodified' do
-      originalfile = File.join(File.dirname(__FILE__), 'fixtures/testdata/wasteland-20120118.epub')
+      original_file = @fixtures_directory / 'testdata/wasteland-20120118.epub'
       epubname = File.join(@tempdir, 'testepub.epub')    
       mod_time = Time.mktime(2010,5,5,8,10,15)
       
-      original_book = File.open(originalfile) do |f|
-        GEPUB::Book.parse(f)
-      end
+      original_book = original_file.open {|f| GEPUB::Book.parse(f) }
       original_book.lastmodified = mod_time
       original_book.generate_epub(epubname)
       File.open(epubname) do |f|

--- a/spec/manifest_spec.rb
+++ b/spec/manifest_spec.rb
@@ -6,7 +6,7 @@ require 'nokogiri'
 describe GEPUB::Manifest do
   context 'parse existing opf' do
     before do
-      @manifest = GEPUB::Package.parse_opf(File.open(File.dirname(__FILE__) + '/fixtures/testdata/test.opf'), '/package.opf').instance_eval{ @manifest }
+      @manifest = GEPUB::Package.parse_opf(@fixtures_directory / 'testdata/test.opf', '/package.opf').instance_eval{ @manifest }
     end
 
     it 'should be parsed' do

--- a/spec/metadata_spec.rb
+++ b/spec/metadata_spec.rb
@@ -17,7 +17,7 @@ describe GEPUB::Metadata do
 
   context 'Parse Existing OPF' do
     before do
-      @metadata = GEPUB::Package.parse_opf(File.open(File.dirname(__FILE__) + '/fixtures/testdata/test.opf'), '/package.opf').instance_eval{ @metadata }
+      @metadata = GEPUB::Package.parse_opf(@fixtures_directory / 'testdata/test.opf', '/package.opf').instance_eval{ @metadata }
     end
     it 'should parse title' do
       expect(@metadata.main_title).to eq('TheTitle')
@@ -26,7 +26,7 @@ describe GEPUB::Metadata do
     end
     
     it 'should parse main title with not first display-seq' do
-      metadata = GEPUB::Package.parse_opf(File.open(File.dirname(__FILE__) + '/fixtures/testdata/test2.opf'), '/package.opf').instance_eval{ @metadata }
+      metadata = GEPUB::Package.parse_opf(@fixtures_directory / 'testdata/test2.opf', '/package.opf').instance_eval{ @metadata }
       expect(metadata.title.to_s).to eq('TheTitle')
     end
 
@@ -56,7 +56,7 @@ describe GEPUB::Metadata do
 
   context 'Should parse OPF2.0' do
     before do
-      @metadata = GEPUB::Package.parse_opf(File.open(File.dirname(__FILE__) + '/fixtures/testdata/package_2_0.opf'), '/package.opf').instance_eval{ @metadata }
+      @metadata = GEPUB::Package.parse_opf(@fixtures_directory / 'testdata/package_2_0.opf', '/package.opf').instance_eval{ @metadata }
     end
     it 'should parse title' do
       expect(@metadata.main_title).to eq('thetitle')

--- a/spec/package_spec.rb
+++ b/spec/package_spec.rb
@@ -11,7 +11,7 @@ describe GEPUB::Package do
 
   context 'parse existing opf' do
     it 'should be initialized with opf' do
-      opf = GEPUB::Package.parse_opf(File.open(File.dirname(__FILE__) + '/fixtures/testdata/test.opf'), '/package.opf')
+      opf = GEPUB::Package.parse_opf(@fixtures_directory / 'testdata/test.opf', '/package.opf')
       expect(opf.ns_prefix(GEPUB::XMLUtil::OPF_NS)).to eq('xmlns')
       expect(opf['version']).to eq('3.0')
       expect(opf['unique-identifier']).to eq('pub-id')
@@ -19,7 +19,7 @@ describe GEPUB::Package do
       expect(opf['prefix']).to eq('foaf: http://xmlns.com/foaf/spec/                   rendition:  http://www.idpf.org/vocab/rendition/#')
     end
     it 'should parse prefix data' do
-      package = GEPUB::Package.parse_opf(File.open(File.dirname(__FILE__) + '/fixtures/testdata/test.opf'), '/package.opf')
+      package = GEPUB::Package.parse_opf(@fixtures_directory / 'testdata/test.opf', '/package.opf')
       expect(package.prefixes.size).to eq(2)
       expect(package.prefixes['foaf']).to eq('http://xmlns.com/foaf/spec/')
       expect(package.prefixes['rendition']).to eq('http://www.idpf.org/vocab/rendition/#')
@@ -27,7 +27,7 @@ describe GEPUB::Package do
     end
 
     it 'should parse rendition metadata' do
-      package = GEPUB::Package.parse_opf(File.open(File.dirname(__FILE__) + '/fixtures/testdata/test.opf'), '/package.opf')
+      package = GEPUB::Package.parse_opf(@fixtures_directory / 'testdata/test.opf', '/package.opf')
       expect(package.rendition_layout).to eq('pre-paginated')
       expect(package.rendition_orientation).to eq('auto')
       expect(package.rendition_spread).to eq('both')

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -39,6 +39,10 @@ RSpec.configure do |config|
     end
     expect(stdout).to include("No errors or warnings detected.")
   end
+
+  config.before(:all) do
+    @fixtures_directory = Pathname(__FILE__).dirname / "fixtures"
+  end
   
 end
 

--- a/spec/spine_spec.rb
+++ b/spec/spine_spec.rb
@@ -6,7 +6,7 @@ require 'nokogiri'
 describe GEPUB::Spine do
   context 'parse existing opf' do
     before do
-      @spine = GEPUB::Package.parse_opf(File.open(File.dirname(__FILE__) + '/fixtures/testdata/test.opf'), '/package.opf').instance_eval{ @spine }
+      @spine = GEPUB::Package.parse_opf(@fixtures_directory / 'testdata/test.opf', '/package.opf').instance_eval{ @spine }
     end
     it 'should be parsed' do
       expect(@spine.toc).to eq('ncx')


### PR DESCRIPTION
Exchange classic prodecural filesystem API with modern object-oriented Pathname in specification. Less noise which lets you focus on what the tests are actually doing.